### PR TITLE
Adding runnables for services whilst addressing #2

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/eth0net/zed-docker-compose"
 
 [language_servers.docker-compose]
 name = "Docker Compose Language Server"
-language = "YAML"
+language = "Docker Compose"

--- a/languages/docker-compose/config.toml
+++ b/languages/docker-compose/config.toml
@@ -1,0 +1,27 @@
+# Adjusted from https://github.com/zed-industries/zed/blob/f2ab00cec7545ffb7d8d75e4ccab74d5fccccf9b/crates/languages/src/yaml/config.toml
+name = "Docker Compose"
+grammar = "yaml"
+path_suffixes = [
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "compose.yaml",
+    "compose.yml",
+]
+line_comments = ["# "]
+autoclose_before = ",]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "string",
+    ] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "string",
+    ] },
+]
+
+auto_indent_on_paste = false
+auto_indent_using_last_non_empty_line = false
+increase_indent_pattern = ":\\s*[|>]?\\s*$"
+prettier_parser_name = "yaml"
+tab_size = 2

--- a/languages/docker-compose/highlights.scm
+++ b/languages/docker-compose/highlights.scm
@@ -1,0 +1,51 @@
+; Taken from https://github.com/zed-industries/zed/blob/f2ab00cec7545ffb7d8d75e4ccab74d5fccccf9b/crates/languages/src/yaml/highlights.scm
+; as the "Docker Compose" language shares the grammar zed uses for YAML
+(boolean_scalar) @boolean
+(null_scalar) @constant.builtin
+
+[
+  (double_quote_scalar)
+  (single_quote_scalar)
+  (block_scalar)
+  (string_scalar)
+] @string
+
+(escape_sequence) @string.escape
+
+[
+  (integer_scalar)
+  (float_scalar)
+] @number
+
+(comment) @comment
+
+[
+  (anchor_name)
+  (alias_name)
+  (tag)
+] @type
+
+key: (flow_node (plain_scalar (string_scalar) @property))
+
+[
+ ","
+ "-"
+ ":"
+ ">"
+ "?"
+ "|"
+] @punctuation.delimiter
+
+[
+ "["
+ "]"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ "*"
+ "&"
+ "---"
+ "..."
+] @punctuation.special

--- a/languages/docker-compose/runnables.scm
+++ b/languages/docker-compose/runnables.scm
@@ -1,0 +1,6 @@
+(document (block_node (block_mapping (block_mapping_pair
+    key: _ @_services
+    value: (block_node (block_mapping (block_mapping_pair
+            key: _ @service @run)))
+    (#eq? @_services "services")
+    (#set! tag docker-compose-service)))))

--- a/languages/docker-compose/tasks.json
+++ b/languages/docker-compose/tasks.json
@@ -1,0 +1,22 @@
+[
+  {
+    "label": "docker-compose run",
+    "command": "docker-compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "docker compose run",
+    "command": "docker compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman-compose run",
+    "command": "podman-compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman compose run",
+    "command": "podman compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  }
+]


### PR DESCRIPTION
The first commit defines a new language "Docker Compose" to address issue #2 which uses the YAML grammar provided by Zed.

The second commit adds clickable runnables for this language to run a single service:

![image](https://github.com/user-attachments/assets/1dae7c1d-f989-42f9-987d-87d4cdea4647)
